### PR TITLE
fix(portal): make the backend discoverable and selectable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,19 +212,28 @@ install(FILES assets/portal/wormhole.portal
     DESTINATION ${CMAKE_INSTALL_DATADIR}/xdg-desktop-portal/portals
 )
 
-install(FILES assets/portal/org.freedesktop.impl.portal.desktop.wormhole.service
+set(WORMHOLE_BIN "${CMAKE_INSTALL_FULL_BINDIR}/wormhole")
+
+configure_file(
+    assets/portal/org.freedesktop.impl.portal.desktop.wormhole.service.in
+    "${CMAKE_CURRENT_BINARY_DIR}/org.freedesktop.impl.portal.desktop.wormhole.service"
+    @ONLY
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.freedesktop.impl.portal.desktop.wormhole.service"
     DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services
 )
 
 install(FILES assets/portal/portals.conf
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/wormhole/portal
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/xdg-desktop-portal
+    RENAME wormhole-portals.conf
 )
 
 # Create symlink xdg-desktop-portal-wormhole -> wormhole
 install(CODE "
     execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
         wormhole
-        \"\$ENV{DESTDIR}\${CMAKE_INSTALL_FULL_BINDIR}/xdg-desktop-portal-wormhole\"
+        \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/xdg-desktop-portal-wormhole\"
     )
 ")
 
@@ -232,28 +241,40 @@ install(CODE "
 set(INIT_SYSTEM "auto" CACHE STRING "Init system to install service files for (auto, openrc, systemd, none)")
 
 if(INIT_SYSTEM STREQUAL "auto")
-    if(EXISTS "/etc/init.d" OR EXISTS "/sbin/openrc" OR EXISTS "/usr/bin/openrc" OR EXISTS "/run/openrc")
+    if(EXISTS "/sbin/openrc" OR EXISTS "/usr/bin/openrc" OR EXISTS "/run/openrc")
         set(DETECTED_INIT "openrc")
-    elseif(EXISTS "/usr/lib/systemd" OR EXISTS "/etc/systemd")
+    elseif(EXISTS "/usr/lib/systemd" OR EXISTS "/lib/systemd" OR EXISTS "/etc/systemd")
         set(DETECTED_INIT "systemd")
     else()
         set(DETECTED_INIT "none")
     endif()
+else()
+    set(DETECTED_INIT "${INIT_SYSTEM}")
 endif()
 
 message(STATUS "Configuring service files for init system: ${DETECTED_INIT}")
 
 if(DETECTED_INIT STREQUAL "openrc")
-    install(PROGRAMS assets/init/xdg-desktop-portal-wormhole.initd
+    configure_file(
+        assets/init/xdg-desktop-portal-wormhole.initd.in
+        "${CMAKE_CURRENT_BINARY_DIR}/xdg-desktop-portal-wormhole.initd"
+        @ONLY
+    )
+    install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/xdg-desktop-portal-wormhole.initd"
         DESTINATION /etc/init.d
         RENAME xdg-desktop-portal-wormhole
     )
-    install(PROGRAMS assets/init/xdg-desktop-portal-wormhole.initd
+    install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/xdg-desktop-portal-wormhole.initd"
         DESTINATION ${CMAKE_INSTALL_DATADIR}/wormhole/openrc
         RENAME xdg-desktop-portal-wormhole
     )
 elseif(DETECTED_INIT STREQUAL "systemd")
-    install(FILES assets/init/xdg-desktop-portal-wormhole.service
+    configure_file(
+        assets/init/xdg-desktop-portal-wormhole.service.in
+        "${CMAKE_CURRENT_BINARY_DIR}/xdg-desktop-portal-wormhole.service"
+        @ONLY
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/xdg-desktop-portal-wormhole.service"
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user
     )
 endif()

--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ sudo cmake --install build
 
 ## Usage
 
+### Selecting Wormhole as the portal backend
+
+`xdg-desktop-portal` picks a backend per interface. Most wlroots backends ship
+their own preference file in `/usr/share/xdg-desktop-portal`, for example
+`hyprland-portals.conf` from `xdg-desktop-portal-hyprland`, and a file matching
+`$XDG_CURRENT_DESKTOP` wins over the `UseIn` line in `wormhole.portal`. So on a
+Hyprland or Sway session with one of those backends installed, Wormhole is not
+used until it is asked for explicitly:
+
+```bash
+mkdir -p ~/.config/xdg-desktop-portal
+cp /usr/share/xdg-desktop-portal/wormhole-portals.conf ~/.config/xdg-desktop-portal/portals.conf
+systemctl --user restart xdg-desktop-portal.service
+```
+
+To hand only screen sharing to Wormhole and leave the rest alone:
+
+```ini
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.ScreenCast=wormhole
+```
+
+`/usr/share/xdg-desktop-portal/portals` must contain `wormhole.portal` for any
+of this to resolve.
+
 ### Run as D-Bus Portal Daemon
 ```bash
 wormhole --daemon

--- a/assets/init/xdg-desktop-portal-wormhole.initd.in
+++ b/assets/init/xdg-desktop-portal-wormhole.initd.in
@@ -2,7 +2,7 @@
 description="Wormhole Material 3 Desktop Portal Daemon"
 supervisor="supervise-daemon"
 
-command="/usr/bin/wormhole"
+command="@WORMHOLE_BIN@"
 command_args="--daemon"
 pidfile="/run/xdg-desktop-portal-wormhole.pid"
 

--- a/assets/init/xdg-desktop-portal-wormhole.service.in
+++ b/assets/init/xdg-desktop-portal-wormhole.service.in
@@ -6,7 +6,7 @@ After=graphical-session.target
 [Service]
 Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.wormhole
-ExecStart=/usr/bin/wormhole --daemon
+ExecStart=@WORMHOLE_BIN@ --daemon
 Restart=on-failure
 
 [Install]

--- a/assets/portal/org.freedesktop.impl.portal.desktop.wormhole.service
+++ b/assets/portal/org.freedesktop.impl.portal.desktop.wormhole.service
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.freedesktop.impl.portal.desktop.wormhole
-Exec=/usr/bin/wormhole --daemon

--- a/assets/portal/org.freedesktop.impl.portal.desktop.wormhole.service.in
+++ b/assets/portal/org.freedesktop.impl.portal.desktop.wormhole.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.freedesktop.impl.portal.desktop.wormhole
+Exec=@WORMHOLE_BIN@ --daemon
+SystemdService=xdg-desktop-portal-wormhole.service

--- a/assets/portal/portals.conf
+++ b/assets/portal/portals.conf
@@ -1,2 +1,2 @@
-[default]
-default=wormhole;gtk;
+[preferred]
+default=wormhole;gtk

--- a/assets/portal/wormhole.portal
+++ b/assets/portal/wormhole.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.wormhole
-Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.DynamicLauncher;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.NotificationInhibition;org.freedesktop.impl.portal.Settings;
-UseIn=wlroots;Hyprland;sway;Wayfire;river;generic;
+Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.DynamicLauncher;org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Wallpaper;
+UseIn=wlroots;Hyprland;sway;Wayfire;river;

--- a/src/portal/portaldaemon.cpp
+++ b/src/portal/portaldaemon.cpp
@@ -38,6 +38,8 @@ bool PortalDaemon::start() {
 
     m_fileChooser = new FileChooserPortal(this);
     m_screenCast = new ScreenCastPortal(this);
+    m_screenshot = new ScreenshotPortal(this);
+    m_appChooser = new AppChooserPortal(this);
     m_access = new AccessPortal(this);
     m_account = new AccountPortal(this);
     m_dynamicLauncher = new DynamicLauncherPortal(this);


### PR DESCRIPTION
Independent of #1 and #2 — no overlapping hunks, mergeable in any order.

## Why screen sharing never reached Wormhole on Arch

Even with the daemon running and registered on the bus, `xdg-desktop-portal` did not route anything to it.

**`portals.conf` used the wrong section name.** The shipped file was:

```ini
[default]
default=wormhole;gtk;
```

`xdg-desktop-portal` reads `[preferred]`. Compare `/usr/share/xdg-desktop-portal/hyprland-portals.conf` as shipped by `xdg-desktop-portal-hyprland`:

```ini
[preferred]
default=hyprland;gtk
```

The file was also installed to `/usr/share/wormhole/portal/portals.conf`, which nothing reads. It now installs to `/usr/share/xdg-desktop-portal/wormhole-portals.conf`.

**`wormhole.portal` did not match the daemon.** It advertised `org.freedesktop.impl.portal.NotificationInhibition`, which is not one of the backend interfaces `xdg-desktop-portal` knows (see `/usr/share/dbus-1/interfaces/`), and it left out `Screenshot` and `AppChooser`. Both of those are fully implemented in `src/portal/`, and `PortalDaemon` declares `m_screenshot` and `m_appChooser` — but `start()` never constructs them:

```cpp
m_fileChooser = new FileChooserPortal(this);
m_screenCast = new ScreenCastPortal(this);
m_access = new AccessPortal(this);   // <- screenshot and appchooser skipped
```

So the two adaptors were compiled in and never exported. They are constructed now, and the interface list is exactly what ends up on the bus.

**The `xdg-desktop-portal-wormhole` symlink landed at the DESTDIR root.** `install(CODE)` escaped `CMAKE_INSTALL_FULL_BINDIR`, deferring it to the install script, where the variable does not exist:

```cmake
\"\$ENV{DESTDIR}\${CMAKE_INSTALL_FULL_BINDIR}/xdg-desktop-portal-wormhole\"
```

`DESTDIR=/tmp/x cmake --install build` before:

```
/tmp/x/usr/bin/wormhole
/tmp/x/xdg-desktop-portal-wormhole        <- here
```

after:

```
/tmp/x/usr/bin/wormhole
/tmp/x/usr/bin/xdg-desktop-portal-wormhole
/tmp/x/usr/lib/systemd/user/xdg-desktop-portal-wormhole.service
/tmp/x/usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.wormhole.service
/tmp/x/usr/share/xdg-desktop-portal/portals/wormhole.portal
/tmp/x/usr/share/xdg-desktop-portal/wormhole-portals.conf
```

## Also in here

- **Prefix.** `Exec=/usr/bin/wormhole` was hardcoded in the D-Bus activation file, the systemd unit and the OpenRC script. They become `.in` templates configured from `CMAKE_INSTALL_FULL_BINDIR`, so a non-`/usr` prefix produces working files.
- **`SystemdService=`** added to the activation file so systemd owns the process when it is bus-activated, matching what the other wlroots backends ship.
- **`-DINIT_SYSTEM=`** was ignored. `DETECTED_INIT` was only assigned inside the `auto` branch, so an explicit `systemd` or `openrc` fell through to the `if`/`elseif` with an empty variable and installed nothing.
- **OpenRC detection.** An existing `/etc/init.d` was taken as proof of OpenRC. Several systemd distributions ship that directory. The check is now on the `openrc` binary or `/run/openrc`, with systemd checked first.

## Backend selection is a documented step

`hyprland-portals.conf` sets `default=hyprland;gtk`, and a file matching `$XDG_CURRENT_DESKTOP` outranks the `UseIn` line in a `.portal` file. So on a Hyprland session with `xdg-desktop-portal-hyprland` installed, Wormhole loses `ScreenCast` no matter what it ships. A backend cannot fix that from its own package — the README now says so and shows the user-level config, including the narrower form that hands over only screen sharing:

```ini
[preferred]
default=hyprland;gtk
org.freedesktop.impl.portal.ScreenCast=wormhole
```

## Testing

Arch Linux. Configured with `-DCMAKE_INSTALL_PREFIX=/usr`, installed into a `DESTDIR` staging tree, layout verified as above. Init detection reports `systemd`. Generated `.service` files carry the configured prefix.