### PR TITLE
fix(portal): export the Screenshot and AppChooser adaptors

### DIFF
--- a/src/portal/appchooserportal.cpp
+++ b/src/portal/appchooserportal.cpp
@@ -8,7 +8,7 @@
 namespace wormhole::portal {
 
 AppChooserPortal::AppChooserPortal(QObject* parent)
-    : QObject(parent) {
+    : QDBusAbstractAdaptor(parent) {
 }
 
 void AppChooserPortal::ChooseApplication(const QDBusObjectPath& handle,

--- a/src/portal/appchooserportal.hpp
+++ b/src/portal/appchooserportal.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDBusAbstractAdaptor>
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusObjectPath>
@@ -13,7 +14,7 @@
 
 namespace wormhole::portal {
 
-class AppChooserPortal : public QObject {
+class AppChooserPortal : public QDBusAbstractAdaptor {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.freedesktop.impl.portal.AppChooser")
 

--- a/src/portal/screenshotportal.cpp
+++ b/src/portal/screenshotportal.cpp
@@ -12,7 +12,7 @@
 namespace wormhole::portal {
 
 ScreenshotPortal::ScreenshotPortal(QObject* parent)
-    : QObject(parent) {
+    : QDBusAbstractAdaptor(parent) {
 }
 
 void ScreenshotPortal::Screenshot(const QDBusObjectPath& handle,

--- a/src/portal/screenshotportal.hpp
+++ b/src/portal/screenshotportal.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDBusAbstractAdaptor>
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusObjectPath>
@@ -12,7 +13,7 @@
 
 namespace wormhole::portal {
 
-class ScreenshotPortal : public QObject {
+class ScreenshotPortal : public QDBusAbstractAdaptor {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.freedesktop.impl.portal.Screenshot")
     Q_PROPERTY(uint version READ version CONSTANT)


### PR DESCRIPTION
Follow-up to #3. That PR started constructing `ScreenshotPortal` and `AppChooserPortal` and added both interfaces to `wormhole.portal`, on the assumption that constructing them was what had been missing. It was not, and I did not check the bus afterwards.

Both classes derive from `QObject`:

```cpp
class ScreenshotPortal : public QObject {
class AppChooserPortal : public QObject {
```

while every other portal class derives from `QDBusAbstractAdaptor`. `PortalDaemon::start()` registers with `QDBusConnection::ExportAdaptors`, which only walks `QDBusAbstractAdaptor` children. So after #3 the daemon still exported nine interfaces:

```
$ busctl --user introspect org.freedesktop.impl.portal.desktop.wormhole /org/freedesktop/portal/desktop
org.freedesktop.impl.portal.Access
org.freedesktop.impl.portal.Account
org.freedesktop.impl.portal.DynamicLauncher
org.freedesktop.impl.portal.FileChooser
org.freedesktop.impl.portal.Inhibit
org.freedesktop.impl.portal.NotificationInhibition
org.freedesktop.impl.portal.ScreenCast
org.freedesktop.impl.portal.Settings
org.freedesktop.impl.portal.Wallpaper
```

— with `wormhole.portal` claiming Screenshot and AppChooser. That is worse than before #3: `xdg-desktop-portal` now believes this backend serves Screenshot, routes the call here and gets an unknown interface, instead of falling through to another backend.

Both classes already carry `Q_CLASSINFO("D-Bus Interface", ...)`, `Q_SCRIPTABLE` slots and delayed replies through a trailing `QDBusMessage` — they were written as adaptors, just with the wrong base class. Changing it is enough.

After:

```
org.freedesktop.impl.portal.Access
org.freedesktop.impl.portal.Account
org.freedesktop.impl.portal.AppChooser
org.freedesktop.impl.portal.DynamicLauncher
org.freedesktop.impl.portal.FileChooser
org.freedesktop.impl.portal.Inhibit
org.freedesktop.impl.portal.NotificationInhibition
org.freedesktop.impl.portal.ScreenCast
org.freedesktop.impl.portal.Screenshot
org.freedesktop.impl.portal.Settings
org.freedesktop.impl.portal.Wallpaper
```

Signatures match `/usr/share/dbus-1/interfaces/`:

```
org.freedesktop.impl.portal.Screenshot
  .Screenshot          method    ossa{sv}
  .PickColor           method    ossa{sv}
  .version             property  u           2
org.freedesktop.impl.portal.AppChooser
  .ChooseApplication   method    ossasa{sv}
  .UpdateChoices       method    oas
```

`AvailableTargets` is not implemented on the Screenshot interface, but that property was added in interface version 3 and this backend reports 2, so `xdg-desktop-portal` will not ask for it.

`NotificationInhibition` stays on the bus and stays out of `wormhole.portal` — it is not one of the interfaces `xdg-desktop-portal` knows.