### PR TITLE
fix(screencast): honour the cursor mode the caller asked for

### DIFF
--- a/qml/dialogs/ScreenChooserDialog.qml
+++ b/qml/dialogs/ScreenChooserDialog.qml
@@ -11,7 +11,8 @@ StyledRect {
 
     property var selectedItem: null
     property int currentTab: 0 // 0: Displays, 1: Windows
-    property bool includeCursor: true
+    readonly property bool cursorAllowed: AppController.cursorMode === 2
+    property bool includeCursor: cursorAllowed
     property bool rememberChoice: false
 
     signal accepted(var result)
@@ -501,6 +502,7 @@ StyledRect {
         StyledCheckBox {
             id: cursorCheck
             text: qsTr("Include pointer")
+            visible: root.cursorAllowed
             checked: root.includeCursor
             onCheckedChanged: root.includeCursor = checked
         }

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -54,6 +54,13 @@ void AppController::setAvailableCursorModes(uint modes) {
     }
 }
 
+void AppController::setCursorMode(uint mode) {
+    if (m_cursorMode != mode) {
+        m_cursorMode = mode;
+        emit cursorModeChanged();
+    }
+}
+
 void AppController::setAllowToken(bool allow) {
     if (m_allowToken != allow) {
         m_allowToken = allow;

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -26,6 +26,7 @@ class AppController : public QObject {
     // ScreenCast Specific
     Q_PROPERTY(uint availableSourceTypes READ availableSourceTypes WRITE setAvailableSourceTypes NOTIFY availableSourceTypesChanged)
     Q_PROPERTY(uint availableCursorModes READ availableCursorModes WRITE setAvailableCursorModes NOTIFY availableCursorModesChanged)
+    Q_PROPERTY(uint cursorMode READ cursorMode WRITE setCursorMode NOTIFY cursorModeChanged)
     Q_PROPERTY(bool allowToken READ allowToken WRITE setAllowToken NOTIFY allowTokenChanged)
     Q_PROPERTY(bool multipleSources READ multipleSources WRITE setMultipleSources NOTIFY multipleSourcesChanged)
 
@@ -90,6 +91,9 @@ public:
     uint availableCursorModes() const { return m_availableCursorModes; }
     void setAvailableCursorModes(uint modes);
 
+    uint cursorMode() const { return m_cursorMode; }
+    void setCursorMode(uint mode);
+
     bool allowToken() const { return m_allowToken; }
     void setAllowToken(bool allow);
 
@@ -152,6 +156,7 @@ signals:
     void parentWindowChanged();
     void availableSourceTypesChanged();
     void availableCursorModesChanged();
+    void cursorModeChanged();
     void allowTokenChanged();
     void multipleSourcesChanged();
     void isScreenshotInteractiveChanged();
@@ -183,6 +188,7 @@ private:
 
     uint m_availableSourceTypes = 7; // Monitor | Window | Virtual
     uint m_availableCursorModes = 7; // Hidden | Embedded | Metadata
+    uint m_cursorMode = 1;
     bool m_allowToken = true;
     bool m_multipleSources = false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char* argv[]) {
     QCommandLineOption titleOpt("title", "Dialog title", "title");
     QCommandLineOption appIdOpt("app-id", "Calling application ID", "appId");
     QCommandLineOption parentWinOpt("parent-window", "Parent window handle", "parent");
+    QCommandLineOption cursorModeOpt("cursor-mode", "Cursor mode requested by the caller", "mode");
     QCommandLineOption urlOpt("url", "Target URL / URI", "url");
     QCommandLineOption nameOpt("name", "Name for shortcut / launcher", "name");
     QCommandLineOption execOpt("exec", "Exec command for launcher", "exec");
@@ -110,6 +111,7 @@ int main(int argc, char* argv[]) {
     parser.addOption(titleOpt);
     parser.addOption(appIdOpt);
     parser.addOption(parentWinOpt);
+    parser.addOption(cursorModeOpt);
     parser.addOption(urlOpt);
     parser.addOption(nameOpt);
     parser.addOption(execOpt);
@@ -159,6 +161,7 @@ int main(int argc, char* argv[]) {
     if (parser.isSet(titleOpt)) controller->setTitle(parser.value(titleOpt));
     if (parser.isSet(appIdOpt)) controller->setAppId(parser.value(appIdOpt));
     if (parser.isSet(parentWinOpt)) controller->setParentWindow(parser.value(parentWinOpt));
+    if (parser.isSet(cursorModeOpt)) controller->setCursorMode(parser.value(cursorModeOpt).toUInt());
     if (parser.isSet(urlOpt)) {
         controller->setWallpaperUri(parser.value(urlOpt));
     }

--- a/src/portal/screencastportal.cpp
+++ b/src/portal/screencastportal.cpp
@@ -82,6 +82,8 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
     QStringList args;
     args << QStringLiteral("--screencast");
     args << QStringLiteral("--app-id") << appId;
+    args << QStringLiteral("--cursor-mode")
+         << QString::number(m_sessions.value(sessionHandle.path()).cursorMode);
     if (!parentWindow.isEmpty()) {
         args << QStringLiteral("--parent-window") << parentWindow;
     }
@@ -137,7 +139,9 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
                 const QString title = root.value(QStringLiteral("title")).toString();
                 const QString className = root.value(QStringLiteral("className")).toString();
                 const int fps = root.value(QStringLiteral("fps")).toInt(60);
-                const bool paintCursor = root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
+                const uint requestedCursor = m_sessions.value(req.sessionHandle.path()).cursorMode;
+                const bool paintCursor = requestedCursor == Embedded
+                    && root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
                 const QString label = isWindow ? (title.isEmpty() ? className : title) : name;
 
                 auto* capture = new screencast::WaylandCapture(this);

--- a/src/portal/screencastportal.hpp
+++ b/src/portal/screencastportal.hpp
@@ -112,7 +112,7 @@ public:
 
     uint version() const { return 5; }
     uint AvailableSourceTypes() const { return Monitor | Window | Virtual; }
-    uint AvailableCursorModes() const { return Hidden | Embedded | Metadata; }
+    uint AvailableCursorModes() const { return Hidden | Embedded; }
 
 public slots:
     Q_SCRIPTABLE uint CreateSession(const QDBusObjectPath& handle,


### PR DESCRIPTION
Found by tracing a real Discord screen share over D-Bus.

## Metadata was advertised but never implemented

```cpp
uint AvailableCursorModes() const { return Hidden | Embedded | Metadata; }
```

Nothing attaches `SPA_META_Cursor` to the PipeWire buffers and no `ext_image_copy_capture_cursor_session_v1` is ever opened. Chromium prefers Metadata when a backend offers it, and duly picked it:

```
method call sender=:1.48 (vesktop) -> destination=:1.589 (xdg-desktop-portal)
  interface=org.freedesktop.portal.ScreenCast; member=SelectSources
   dict entry( string "types"        variant uint32 3 )
   dict entry( string "cursor_mode"  variant uint32 4 )   <- Metadata
   dict entry( string "persist_mode" variant uint32 1 )
```

So every Chromium/Electron share negotiated a mode this backend cannot serve. Only `Hidden | Embedded` is advertised now, which makes Chromium fall back to Embedded — a mode that actually works.

## The requested mode was parsed and then dropped

`SelectSources` stores it:

```cpp
data.cursorMode = options.value(QStringLiteral("cursor_mode"), Hidden).toUInt();
```

and `SessionData::cursorMode` is never read again. What actually decided whether the pointer got drawn was the chooser's checkbox alone:

```cpp
const bool paintCursor = root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
```

where `root` is the chooser's JSON. An application asking for `Hidden` got a pointer burned into its stream anyway whenever the box happened to be ticked — the box defaults to on.

Now the requested mode reaches the chooser through `--cursor-mode`, the checkbox is only shown when the caller asked for `Embedded`, and the pointer is drawn only when caller and user agree:

```cpp
const bool paintCursor = requestedCursor == Embedded
    && root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
```

`AppController` already had `availableCursorModes`, `allowToken`, `multipleSources` and `availableSourceTypes` declared with getters, setters and signals, none of them ever populated. This adds `cursorMode` beside them and actually wires it up; the rest are left alone.

## Testing

Arch Linux, Hyprland 0.56.2.

`wormhole --screencast --cursor-mode 1` — bottom row shows only "Remember choice".
`wormhole --screencast --cursor-mode 2` — "Include pointer" is present and ticked.

## Not in scope

Implementing Metadata properly means opening a cursor session and attaching `SPA_META_Cursor` per frame. Worth doing — it lets the consumer draw the pointer at its own resolution and keeps it out of the encoded video — but it is a separate piece of work, and advertising a mode that does nothing is worse than not advertising it.