### PR TITLE
feat(screencast): persist restore tokens

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ qt_add_executable(wormhole_app
     src/portal/request.cpp
     src/portal/session.hpp
     src/portal/session.cpp
+    src/portal/restorestore.hpp
+    src/portal/restorestore.cpp
     src/portal/filechooserportal.hpp
     src/portal/filechooserportal.cpp
     src/portal/screencastportal.hpp

--- a/qml/dialogs/ScreenChooserDialog.qml
+++ b/qml/dialogs/ScreenChooserDialog.qml
@@ -12,6 +12,7 @@ StyledRect {
     property var selectedItem: null
     property int currentTab: 0 // 0: Displays, 1: Windows
     readonly property bool cursorAllowed: AppController.cursorMode === 2
+    readonly property bool rememberAllowed: AppController.allowToken
     property bool includeCursor: cursorAllowed
     property bool rememberChoice: false
 
@@ -510,6 +511,7 @@ StyledRect {
         StyledCheckBox {
             id: rememberCheck
             text: qsTr("Remember choice")
+            visible: root.rememberAllowed
             checked: root.rememberChoice
             onCheckedChanged: root.rememberChoice = checked
         }

--- a/qml/dialogs/ScreenChooserDialog.qml
+++ b/qml/dialogs/ScreenChooserDialog.qml
@@ -11,7 +11,8 @@ StyledRect {
 
     property var selectedItem: null
     property int currentTab: 0 // 0: Displays, 1: Windows
-    property bool includeCursor: true
+    readonly property bool cursorAllowed: AppController.cursorMode === 2
+    property bool includeCursor: cursorAllowed
     property bool rememberChoice: false
 
     signal accepted(var result)
@@ -501,6 +502,7 @@ StyledRect {
         StyledCheckBox {
             id: cursorCheck
             text: qsTr("Include pointer")
+            visible: root.cursorAllowed
             checked: root.includeCursor
             onCheckedChanged: root.includeCursor = checked
         }

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -54,6 +54,13 @@ void AppController::setAvailableCursorModes(uint modes) {
     }
 }
 
+void AppController::setCursorMode(uint mode) {
+    if (m_cursorMode != mode) {
+        m_cursorMode = mode;
+        emit cursorModeChanged();
+    }
+}
+
 void AppController::setAllowToken(bool allow) {
     if (m_allowToken != allow) {
         m_allowToken = allow;

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -189,7 +189,7 @@ private:
     uint m_availableSourceTypes = 7; // Monitor | Window | Virtual
     uint m_availableCursorModes = 7; // Hidden | Embedded | Metadata
     uint m_cursorMode = 1;
-    bool m_allowToken = true;
+    bool m_allowToken = false;
     bool m_multipleSources = false;
 
     bool m_isScreenshotInteractive = true;

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -26,6 +26,7 @@ class AppController : public QObject {
     // ScreenCast Specific
     Q_PROPERTY(uint availableSourceTypes READ availableSourceTypes WRITE setAvailableSourceTypes NOTIFY availableSourceTypesChanged)
     Q_PROPERTY(uint availableCursorModes READ availableCursorModes WRITE setAvailableCursorModes NOTIFY availableCursorModesChanged)
+    Q_PROPERTY(uint cursorMode READ cursorMode WRITE setCursorMode NOTIFY cursorModeChanged)
     Q_PROPERTY(bool allowToken READ allowToken WRITE setAllowToken NOTIFY allowTokenChanged)
     Q_PROPERTY(bool multipleSources READ multipleSources WRITE setMultipleSources NOTIFY multipleSourcesChanged)
 
@@ -90,6 +91,9 @@ public:
     uint availableCursorModes() const { return m_availableCursorModes; }
     void setAvailableCursorModes(uint modes);
 
+    uint cursorMode() const { return m_cursorMode; }
+    void setCursorMode(uint mode);
+
     bool allowToken() const { return m_allowToken; }
     void setAllowToken(bool allow);
 
@@ -152,6 +156,7 @@ signals:
     void parentWindowChanged();
     void availableSourceTypesChanged();
     void availableCursorModesChanged();
+    void cursorModeChanged();
     void allowTokenChanged();
     void multipleSourcesChanged();
     void isScreenshotInteractiveChanged();
@@ -183,6 +188,7 @@ private:
 
     uint m_availableSourceTypes = 7; // Monitor | Window | Virtual
     uint m_availableCursorModes = 7; // Hidden | Embedded | Metadata
+    uint m_cursorMode = 1;
     bool m_allowToken = true;
     bool m_multipleSources = false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,6 +89,7 @@ int main(int argc, char* argv[]) {
     QCommandLineOption appIdOpt("app-id", "Calling application ID", "appId");
     QCommandLineOption parentWinOpt("parent-window", "Parent window handle", "parent");
     QCommandLineOption cursorModeOpt("cursor-mode", "Cursor mode requested by the caller", "mode");
+    QCommandLineOption persistModeOpt("persist-mode", "Persist mode requested by the caller", "mode");
     QCommandLineOption urlOpt("url", "Target URL / URI", "url");
     QCommandLineOption nameOpt("name", "Name for shortcut / launcher", "name");
     QCommandLineOption execOpt("exec", "Exec command for launcher", "exec");
@@ -112,6 +113,7 @@ int main(int argc, char* argv[]) {
     parser.addOption(appIdOpt);
     parser.addOption(parentWinOpt);
     parser.addOption(cursorModeOpt);
+    parser.addOption(persistModeOpt);
     parser.addOption(urlOpt);
     parser.addOption(nameOpt);
     parser.addOption(execOpt);
@@ -162,6 +164,7 @@ int main(int argc, char* argv[]) {
     if (parser.isSet(appIdOpt)) controller->setAppId(parser.value(appIdOpt));
     if (parser.isSet(parentWinOpt)) controller->setParentWindow(parser.value(parentWinOpt));
     if (parser.isSet(cursorModeOpt)) controller->setCursorMode(parser.value(cursorModeOpt).toUInt());
+    if (parser.isSet(persistModeOpt)) controller->setAllowToken(parser.value(persistModeOpt).toUInt() != 0);
     if (parser.isSet(urlOpt)) {
         controller->setWallpaperUri(parser.value(urlOpt));
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char* argv[]) {
     QCommandLineOption titleOpt("title", "Dialog title", "title");
     QCommandLineOption appIdOpt("app-id", "Calling application ID", "appId");
     QCommandLineOption parentWinOpt("parent-window", "Parent window handle", "parent");
+    QCommandLineOption cursorModeOpt("cursor-mode", "Cursor mode requested by the caller", "mode");
     QCommandLineOption urlOpt("url", "Target URL / URI", "url");
     QCommandLineOption nameOpt("name", "Name for shortcut / launcher", "name");
     QCommandLineOption execOpt("exec", "Exec command for launcher", "exec");
@@ -110,6 +111,7 @@ int main(int argc, char* argv[]) {
     parser.addOption(titleOpt);
     parser.addOption(appIdOpt);
     parser.addOption(parentWinOpt);
+    parser.addOption(cursorModeOpt);
     parser.addOption(urlOpt);
     parser.addOption(nameOpt);
     parser.addOption(execOpt);
@@ -159,6 +161,7 @@ int main(int argc, char* argv[]) {
     if (parser.isSet(titleOpt)) controller->setTitle(parser.value(titleOpt));
     if (parser.isSet(appIdOpt)) controller->setAppId(parser.value(appIdOpt));
     if (parser.isSet(parentWinOpt)) controller->setParentWindow(parser.value(parentWinOpt));
+    if (parser.isSet(cursorModeOpt)) controller->setCursorMode(parser.value(cursorModeOpt).toUInt());
     if (parser.isSet(urlOpt)) {
         controller->setWallpaperUri(parser.value(urlOpt));
     }

--- a/src/portal/restorestore.cpp
+++ b/src/portal/restorestore.cpp
@@ -1,0 +1,133 @@
+#include "restorestore.hpp"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+#include <QUuid>
+
+namespace wormhole::portal {
+
+RestoreStore* RestoreStore::instance() {
+    static RestoreStore store;
+    return &store;
+}
+
+RestoreStore::RestoreStore() {
+    load();
+}
+
+QString RestoreStore::filePath() {
+    QString base = qEnvironmentVariable("XDG_STATE_HOME");
+    if (base.isEmpty()) {
+        base = QDir::homePath() + QStringLiteral("/.local/state");
+    }
+    return base + QStringLiteral("/wormhole/screencast.json");
+}
+
+void RestoreStore::load() {
+    QFile file(filePath());
+    if (!file.open(QIODevice::ReadOnly)) {
+        return;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (!doc.isObject()) {
+        return;
+    }
+
+    const QJsonObject root = doc.object();
+    for (auto it = root.constBegin(); it != root.constEnd(); ++it) {
+        if (!it.value().isObject()) {
+            continue;
+        }
+        const QJsonObject obj = it.value().toObject();
+
+        RestoreEntry entry;
+        entry.appId = obj.value(QStringLiteral("app_id")).toString();
+        entry.isWindow = obj.value(QStringLiteral("is_window")).toBool();
+        entry.outputName = obj.value(QStringLiteral("output")).toString();
+        entry.windowAppId = obj.value(QStringLiteral("window_app_id")).toString();
+        entry.windowTitle = obj.value(QStringLiteral("window_title")).toString();
+        entry.windowAddress = obj.value(QStringLiteral("window_address")).toString();
+        entry.x = obj.value(QStringLiteral("x")).toInt();
+        entry.y = obj.value(QStringLiteral("y")).toInt();
+        entry.fps = obj.value(QStringLiteral("fps")).toInt(60);
+        entry.durable = true;
+
+        m_entries.insert(it.key(), entry);
+    }
+}
+
+void RestoreStore::save() const {
+    const QString path = filePath();
+    QDir().mkpath(QFileInfo(path).absolutePath());
+
+    QJsonObject root;
+    for (auto it = m_entries.constBegin(); it != m_entries.constEnd(); ++it) {
+        if (!it.value().durable) {
+            continue;
+        }
+
+        QJsonObject obj;
+        obj.insert(QStringLiteral("app_id"), it.value().appId);
+        obj.insert(QStringLiteral("is_window"), it.value().isWindow);
+        obj.insert(QStringLiteral("output"), it.value().outputName);
+        obj.insert(QStringLiteral("window_app_id"), it.value().windowAppId);
+        obj.insert(QStringLiteral("window_title"), it.value().windowTitle);
+        obj.insert(QStringLiteral("window_address"), it.value().windowAddress);
+        obj.insert(QStringLiteral("x"), it.value().x);
+        obj.insert(QStringLiteral("y"), it.value().y);
+        obj.insert(QStringLiteral("fps"), it.value().fps);
+
+        root.insert(it.key(), obj);
+    }
+
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return;
+    }
+    file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    file.commit();
+    QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+}
+
+QString RestoreStore::add(const RestoreEntry& entry) {
+    const QString token = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    m_entries.insert(token, entry);
+    if (entry.durable) {
+        save();
+    }
+    return token;
+}
+
+bool RestoreStore::take(const QString& token, const QString& appId, RestoreEntry& entry) const {
+    if (token.isEmpty()) {
+        return false;
+    }
+
+    const auto it = m_entries.constFind(token);
+    if (it == m_entries.constEnd() || it.value().appId != appId) {
+        return false;
+    }
+
+    entry = it.value();
+    return true;
+}
+
+void RestoreStore::remove(const QString& token) {
+    const auto it = m_entries.constFind(token);
+    if (it == m_entries.constEnd()) {
+        return;
+    }
+
+    const bool wasDurable = it.value().durable;
+    m_entries.erase(it);
+    if (wasDurable) {
+        save();
+    }
+}
+
+} // namespace wormhole::portal

--- a/src/portal/restorestore.hpp
+++ b/src/portal/restorestore.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QHash>
+#include <QObject>
+#include <QString>
+
+namespace wormhole::portal {
+
+struct RestoreEntry {
+    QString appId;
+    bool isWindow = false;
+    QString outputName;
+    QString windowAppId;
+    QString windowTitle;
+    QString windowAddress;
+    int x = 0;
+    int y = 0;
+    int fps = 60;
+    bool durable = false;
+};
+
+class RestoreStore {
+public:
+    static RestoreStore* instance();
+
+    QString add(const RestoreEntry& entry);
+    bool take(const QString& token, const QString& appId, RestoreEntry& entry) const;
+    void remove(const QString& token);
+
+private:
+    RestoreStore();
+
+    void load();
+    void save() const;
+    static QString filePath();
+
+    QHash<QString, RestoreEntry> m_entries;
+};
+
+} // namespace wormhole::portal

--- a/src/portal/screencastportal.cpp
+++ b/src/portal/screencastportal.cpp
@@ -82,6 +82,8 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
     QStringList args;
     args << QStringLiteral("--screencast");
     args << QStringLiteral("--app-id") << appId;
+    args << QStringLiteral("--cursor-mode")
+         << QString::number(m_sessions.value(sessionHandle.path()).cursorMode);
     if (!parentWindow.isEmpty()) {
         args << QStringLiteral("--parent-window") << parentWindow;
     }
@@ -137,7 +139,9 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
                 const QString title = root.value(QStringLiteral("title")).toString();
                 const QString className = root.value(QStringLiteral("className")).toString();
                 const int fps = root.value(QStringLiteral("fps")).toInt(60);
-                const bool paintCursor = root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
+                const uint requestedCursor = m_sessions.value(req.sessionHandle.path()).cursorMode;
+                const bool paintCursor = requestedCursor == Embedded
+                    && root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
                 const QString label = isWindow ? (title.isEmpty() ? className : title) : name;
 
                 auto* capture = new screencast::WaylandCapture(this);

--- a/src/portal/screencastportal.cpp
+++ b/src/portal/screencastportal.cpp
@@ -63,14 +63,100 @@ void ScreenCastPortal::Start(const QDBusObjectPath& handle,
                             const QDBusMessage& message) {
     message.setDelayedReply(true);
 
-    if (!m_sessions.contains(session_handle.path())) {
-        QDBusMessage reply = message.createReply();
-        reply << static_cast<uint>(2) << QVariantMap();
-        QDBusConnection::sessionBus().send(reply);
+    const QString sessionPath = session_handle.path();
+    if (!m_sessions.contains(sessionPath)) {
+        sendReply(message, 2, QVariantMap());
         return;
     }
 
+    const SessionData data = m_sessions.value(sessionPath);
+
+    RestoreEntry entry;
+    if (data.persistMode != NoPersist && RestoreStore::instance()->take(data.restoreToken, app_id, entry)) {
+        SelectedSource source;
+        source.isWindow = entry.isWindow;
+        source.outputName = entry.outputName;
+        source.windowAppId = entry.windowAppId;
+        source.windowTitle = entry.windowTitle;
+        source.windowAddress = entry.windowAddress;
+        source.x = entry.x;
+        source.y = entry.y;
+        source.fps = entry.fps;
+        source.paintCursor = data.cursorMode == Embedded;
+
+        QVariantMap results;
+        if (startStream(sessionPath, source, results)) {
+            results.insert(QStringLiteral("restore_token"), data.restoreToken);
+            sendReply(message, 0, results);
+            return;
+        }
+
+        RestoreStore::instance()->remove(data.restoreToken);
+    }
+
     launchScreenChooser(handle, session_handle, app_id, parent_window, message);
+}
+
+void ScreenCastPortal::sendReply(const QDBusMessage& message, uint response, const QVariantMap& results) {
+    QDBusMessage reply = message.createReply();
+    reply << response << results;
+    QDBusConnection::sessionBus().send(reply);
+}
+
+bool ScreenCastPortal::startStream(const QString& sessionPath, const SelectedSource& source, QVariantMap& results) {
+    auto* capture = new screencast::WaylandCapture(this);
+    const bool started = source.isWindow
+        ? capture->captureToplevel(source.windowAppId, source.windowTitle, source.paintCursor, source.fps)
+        : capture->captureOutput(source.outputName, source.paintCursor, source.fps);
+
+    if (!started) {
+        capture->deleteLater();
+        return false;
+    }
+
+    const QSize size = capture->frameSize();
+    const QString label = source.isWindow
+        ? (source.windowTitle.isEmpty() ? source.windowAppId : source.windowTitle)
+        : source.outputName;
+
+    const uint32_t nodeId = screencast::PipeWireStreamManager::instance()->createStream(
+        label, size.width(), size.height(), source.fps);
+
+    if (nodeId == 0) {
+        capture->deleteLater();
+        return false;
+    }
+
+    connect(capture, &screencast::WaylandCapture::frameReady, this, [nodeId](const QImage& frame) {
+        screencast::PipeWireStreamManager::instance()->pushFrame(nodeId, frame);
+    });
+    connect(capture, &screencast::WaylandCapture::stopped, this, [this, sessionPath]() {
+        closeSession(sessionPath);
+    });
+
+    if (m_sessions.contains(sessionPath)) {
+        auto& sess = m_sessions[sessionPath];
+        sess.pipewireNodeId = nodeId;
+        sess.capture = capture;
+    }
+
+    ScreenCastStream stream;
+    stream.nodeId = nodeId;
+    stream.properties.insert(QStringLiteral("position"),
+                             QVariant::fromValue(ScreenCastPosition{ source.x, source.y }));
+    stream.properties.insert(QStringLiteral("size"),
+                             QVariant::fromValue(ScreenCastSize{ size.width(), size.height() }));
+    stream.properties.insert(QStringLiteral("source_type"),
+                             static_cast<uint>(source.isWindow ? Window : Monitor));
+    stream.properties.insert(QStringLiteral("mapping_id"),
+                             source.isWindow ? source.windowAddress : source.outputName);
+
+    ScreenCastStreamList streams;
+    streams.append(stream);
+
+    results.insert(QStringLiteral("streams"), QVariant::fromValue(streams));
+    results.insert(QStringLiteral("source_type"), static_cast<uint>(source.isWindow ? Window : Monitor));
+    return true;
 }
 
 void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
@@ -82,8 +168,9 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
     QStringList args;
     args << QStringLiteral("--screencast");
     args << QStringLiteral("--app-id") << appId;
-    args << QStringLiteral("--cursor-mode")
-         << QString::number(m_sessions.value(sessionHandle.path()).cursorMode);
+    const SessionData data = m_sessions.value(sessionHandle.path());
+    args << QStringLiteral("--cursor-mode") << QString::number(data.cursorMode);
+    args << QStringLiteral("--persist-mode") << QString::number(data.persistMode);
     if (!parentWindow.isEmpty()) {
         args << QStringLiteral("--parent-window") << parentWindow;
     }
@@ -109,9 +196,7 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
             if (r.requestObject) r.requestObject->deleteLater();
             if (r.process) r.process->deleteLater();
 
-            QDBusMessage reply = r.message.createReply();
-            reply << static_cast<uint>(1) << QVariantMap();
-            QDBusConnection::sessionBus().send(reply);
+            sendReply(r.message, 1, QVariantMap());
         }
     });
 
@@ -126,82 +211,52 @@ void ScreenCastPortal::launchScreenChooser(const QDBusObjectPath& handle,
         if (req.requestObject) req.requestObject->deleteLater();
         if (req.process) req.process->deleteLater();
 
-        QDBusMessage reply = req.message.createReply();
         QVariantMap results;
 
         if (exitCode == 0 && !stdoutData.isEmpty()) {
-            QJsonDocument doc = QJsonDocument::fromJson(stdoutData);
+            const QJsonDocument doc = QJsonDocument::fromJson(stdoutData);
             if (!doc.isNull()) {
                 const QJsonObject root = doc.object();
-                const bool isWindow = root.value(QStringLiteral("type")).toString(QStringLiteral("screen")) == QLatin1String("window");
-                const QString name = root.value(QStringLiteral("name")).toString();
-                const QString address = root.value(QStringLiteral("address")).toString();
-                const QString title = root.value(QStringLiteral("title")).toString();
-                const QString className = root.value(QStringLiteral("className")).toString();
-                const int fps = root.value(QStringLiteral("fps")).toInt(60);
-                const uint requestedCursor = m_sessions.value(req.sessionHandle.path()).cursorMode;
-                const bool paintCursor = requestedCursor == Embedded
+                const QString sessionPath = req.sessionHandle.path();
+                const SessionData data = m_sessions.value(sessionPath);
+
+                SelectedSource source;
+                source.isWindow = root.value(QStringLiteral("type")).toString(QStringLiteral("screen")) == QLatin1String("window");
+                source.outputName = root.value(QStringLiteral("name")).toString();
+                source.windowAppId = root.value(QStringLiteral("className")).toString();
+                source.windowTitle = root.value(QStringLiteral("title")).toString();
+                source.windowAddress = root.value(QStringLiteral("address")).toString();
+                source.x = root.value(QStringLiteral("x")).toInt(0);
+                source.y = root.value(QStringLiteral("y")).toInt(0);
+                source.fps = root.value(QStringLiteral("fps")).toInt(60);
+                source.paintCursor = data.cursorMode == Embedded
                     && root.value(QStringLiteral("cursorMode")).toInt(Hidden) == Embedded;
-                const QString label = isWindow ? (title.isEmpty() ? className : title) : name;
 
-                auto* capture = new screencast::WaylandCapture(this);
-                const bool started = isWindow
-                    ? capture->captureToplevel(className, title, paintCursor, fps)
-                    : capture->captureOutput(name, paintCursor, fps);
+                if (startStream(sessionPath, source, results)) {
+                    if (data.persistMode != NoPersist && root.value(QStringLiteral("persist")).toBool()) {
+                        RestoreEntry entry;
+                        entry.appId = req.appId;
+                        entry.isWindow = source.isWindow;
+                        entry.outputName = source.outputName;
+                        entry.windowAppId = source.windowAppId;
+                        entry.windowTitle = source.windowTitle;
+                        entry.windowAddress = source.windowAddress;
+                        entry.x = source.x;
+                        entry.y = source.y;
+                        entry.fps = source.fps;
+                        entry.durable = data.persistMode == PersistUntilRevoked;
 
-                if (started) {
-                    const QSize size = capture->frameSize();
-                    const uint32_t nodeId = screencast::PipeWireStreamManager::instance()->createStream(
-                        label, size.width(), size.height(), fps);
-
-                    if (nodeId != 0) {
-                        connect(capture, &screencast::WaylandCapture::frameReady, this, [nodeId](const QImage& frame) {
-                            screencast::PipeWireStreamManager::instance()->pushFrame(nodeId, frame);
-                        });
-
-                        const QString sessionPath = req.sessionHandle.path();
-                        connect(capture, &screencast::WaylandCapture::stopped, this, [this, sessionPath]() {
-                            closeSession(sessionPath);
-                        });
-
-                        if (m_sessions.contains(sessionPath)) {
-                            auto& sess = m_sessions[sessionPath];
-                            sess.pipewireNodeId = nodeId;
-                            sess.capture = capture;
-                        }
-
-                        ScreenCastStream stream;
-                        stream.nodeId = nodeId;
-                        stream.properties.insert(QStringLiteral("position"), QVariant::fromValue(ScreenCastPosition{
-                            root.value(QStringLiteral("x")).toInt(0),
-                            root.value(QStringLiteral("y")).toInt(0)
-                        }));
-                        stream.properties.insert(QStringLiteral("size"), QVariant::fromValue(ScreenCastSize{ size.width(), size.height() }));
-                        stream.properties.insert(QStringLiteral("source_type"), static_cast<uint>(isWindow ? Window : Monitor));
-                        stream.properties.insert(QStringLiteral("mapping_id"), isWindow ? address : name);
-
-                        ScreenCastStreamList streams;
-                        streams.append(stream);
-
-                        results.insert(QStringLiteral("streams"), QVariant::fromValue(streams));
-                        results.insert(QStringLiteral("source_type"), static_cast<uint>(isWindow ? Window : Monitor));
-
-                        if (root.value(QStringLiteral("persist")).toBool()) {
-                            results.insert(QStringLiteral("restore_token"), QUuid::createUuid().toString(QUuid::WithoutBraces));
-                        }
-
-                        reply << static_cast<uint>(0) << results;
-                        QDBusConnection::sessionBus().send(reply);
-                        return;
+                        results.insert(QStringLiteral("restore_token"),
+                                       RestoreStore::instance()->add(entry));
                     }
-                }
 
-                capture->deleteLater();
+                    sendReply(req.message, 0, results);
+                    return;
+                }
             }
         }
 
-        reply << static_cast<uint>(1) << results;
-        QDBusConnection::sessionBus().send(reply);
+        sendReply(req.message, 1, results);
     });
 
     process->start(wormholeBin, args);

--- a/src/portal/screencastportal.hpp
+++ b/src/portal/screencastportal.hpp
@@ -13,6 +13,7 @@
 #include <QString>
 #include <QVariantMap>
 #include "request.hpp"
+#include "restorestore.hpp"
 #include "session.hpp"
 #include "../screencast/pipewirestream.hpp"
 #include "../screencast/waylandcapture.hpp"
@@ -135,6 +136,18 @@ public slots:
                             const QDBusMessage& message);
 
 private:
+    struct SelectedSource {
+        bool isWindow = false;
+        QString outputName;
+        QString windowAppId;
+        QString windowTitle;
+        QString windowAddress;
+        int x = 0;
+        int y = 0;
+        int fps = 60;
+        bool paintCursor = false;
+    };
+
     struct SessionData {
         QString appId;
         uint types = Monitor | Window;
@@ -154,6 +167,9 @@ private:
     };
 
     void closeSession(const QString& sessionPath);
+
+    bool startStream(const QString& sessionPath, const SelectedSource& source, QVariantMap& results);
+    static void sendReply(const QDBusMessage& message, uint response, const QVariantMap& results);
 
     void launchScreenChooser(const QDBusObjectPath& handle,
                              const QDBusObjectPath& sessionHandle,

--- a/src/portal/screencastportal.hpp
+++ b/src/portal/screencastportal.hpp
@@ -112,7 +112,7 @@ public:
 
     uint version() const { return 5; }
     uint AvailableSourceTypes() const { return Monitor | Window | Virtual; }
-    uint AvailableCursorModes() const { return Hidden | Embedded | Metadata; }
+    uint AvailableCursorModes() const { return Hidden | Embedded; }
 
 public slots:
     Q_SCRIPTABLE uint CreateSession(const QDBusObjectPath& handle,


### PR DESCRIPTION
> Stacked on #6. Merge that first.

## The chooser opened every single time

`SelectSources` parsed both fields into `SessionData`:

```cpp
data.persistMode = options.value(QStringLiteral("persist_mode"), NoPersist).toUInt();
if (options.contains(QStringLiteral("restore_token"))) {
    data.restoreToken = options.value(QStringLiteral("restore_token")).toString();
}
```

and neither was read again anywhere. `Start` handed back a fresh UUID when the chooser's "Remember choice" box was ticked, stored it nowhere, and ignored any token an application passed back in.

This is not an edge case. Every `getDisplayMedia` call from Chromium carries it — from a Discord share, captured off the bus:

```
dict entry( string "persist_mode" variant uint32 1 )
```

## What this adds

`RestoreStore` maps a token to the source it was issued for.

| persist_mode | behaviour |
| --- | --- |
| 0 `NoPersist` | no token issued |
| 1 `PersistWhileRunning` | token kept in memory for the daemon's lifetime |
| 2 `PersistUntilRevoked` | token written to `$XDG_STATE_HOME/wormhole/screencast.json`, mode 0600 |

A token is only accepted for the `app_id` it was issued to, so one application cannot replay another's grant.

`Start` tries the restore path before spawning the chooser. With a valid token it starts the capture immediately and answers with the same token. If the remembered output or window is gone, `startStream()` fails, the token is dropped and the chooser opens as it did before.

A token is only issued when the caller asked for persistence **and** the user ticked the box, and the box is only shown when the caller asked at all — passed through as `--persist-mode`, using the `allowToken` property `AppController` already had and nothing populated.

The reply path is factored into `startStream()` so the chooser and the restore path produce the same stream and the same results dictionary.

## Testing

Arch Linux, Hyprland 0.56.2, driving `org.freedesktop.impl.portal.ScreenCast` directly.

**Issuing.** Fresh session, `persist_mode=2`, "Remember choice" ticked in the chooser:

```
RESULT {"response": 0, "token": "96456dec-820d-492b-ab8c-10f7c0abc7b2", "node": 125}
```

```json
{
    "96456dec-820d-492b-ab8c-10f7c0abc7b2": {
        "app_id": "issueapp",
        "fps": 240,
        "is_window": false,
        "output": "DP-3",
        "x": 0, "y": 0
    }
}
```

`-rw------- screencast.json`

**Restoring.** New session, same `app_id`, token passed in `SelectSources`:

```
Start: 0 | chooser opened: False
node: 122  size: (5120, 1440)  mapping: DP-3
restore_token returned: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
```

Consumed that node with `gst-launch-1.0 pipewiresrc` — 471 buffers in 8 s, `max-framerate 240/1`, the refresh rate carried in the stored entry.

**Rejecting.**

```
foreign app, same token:   chooser opened: True
unknown token:             chooser opened: True
```

## Note on the three choosers

This does not stop an application from opening several sessions at once — Electron creates one `DesktopCapturer` per source kind, and a Discord share produced three near-simultaneous `CreateSession` calls, 53 ms apart for the last two. Those are three independent grants and each one asks. What this fixes is the *next* share: with a stored token the chooser stays shut.