### PR TITLE
fix: percent-encode returned URIs and report a crashed picker as an error

### DIFF
--- a/src/portal/filechooserportal.cpp
+++ b/src/portal/filechooserportal.cpp
@@ -283,7 +283,7 @@ void FileChooserPortal::launchAtlasPicker(const QString& title,
     });
 
     connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [this, handle](int exitCode, QProcess::ExitStatus /*status*/) {
+            this, [this, handle](int exitCode, QProcess::ExitStatus exitStatus) {
         if (!m_requests.contains(handle.path())) {
             return;
         }
@@ -296,6 +296,14 @@ void FileChooserPortal::launchAtlasPicker(const QString& title,
         QDBusMessage reply = req.message.createReply();
         QVariantMap results;
 
+        if (exitStatus == QProcess::CrashExit) {
+            qWarning() << "wormhole: the file picker crashed with signal" << exitCode
+                       << "- reporting an error rather than a cancellation";
+            reply << static_cast<uint>(2) << results;
+            QDBusConnection::sessionBus().send(reply);
+            return;
+        }
+
         if (exitCode == 0 && !stdoutData.isEmpty()) {
             QString output = QString::fromUtf8(stdoutData).trimmed();
             QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
@@ -306,7 +314,7 @@ void FileChooserPortal::launchAtlasPicker(const QString& title,
                 if (trimmed.startsWith(QLatin1String("file://"))) {
                     uris << trimmed;
                 } else if (!trimmed.isEmpty() && QDir::isAbsolutePath(trimmed)) {
-                    uris << QUrl::fromLocalFile(trimmed).toString();
+                    uris << QUrl::fromLocalFile(trimmed).toString(QUrl::FullyEncoded);
                 }
             }
 


### PR DESCRIPTION
Two things found while tracing AstraSuite/Atlas#79 and AstraSuite/Atlas#81.

## A crashed picker was reported as a cancellation

The `finished` handler discarded the exit status:

```cpp
this, [this, handle](int exitCode, QProcess::ExitStatus /*status*/) {
...
if (exitCode == 0 && !stdoutData.isEmpty()) {
```

When a child dies from a signal, Qt reports the signal number as the exit code and sets `CrashExit`. Measured:

```
exitCode   = 6
exitStatus = CrashExit
stdout     = '/home/x/datei.txt'
```

So the picker had already printed the chosen path, but `exitCode == 0` was false and the request fell through to the cancelled branch. Slack, Discord and Firefox were told the user picked nothing. That is exactly the shape of Atlas#79 — the dialog visibly worked and the upload silently did not.

A crash is now reported as an error rather than a cancellation, with the signal logged. The Atlas abort would have been visible in the journal on day one instead of looking like a user cancelling.

The Atlas-side crash is fixed in AstraSuite/Atlas#82; this is the part that made it silent.

## URIs were not percent-encoded

`QUrl::toString()` renders a URI for display, not for the wire:

| path | `toString()` | `FullyEncoded` |
|---|---|---|
| `/home/x/mit leerzeichen.txt` | `file:///home/x/mit leerzeichen.txt` | `file:///home/x/mit%20leerzeichen.txt` |
| `/home/x/umlaut-äöü.txt` | `file:///home/x/umlaut-äöü.txt` | `file:///home/x/umlaut-%C3%A4%C3%B6%C3%BC.txt` |

Qt reads its own output back correctly, which is why this survives a round trip in tests and only fails once the URI reaches GLib and the requesting application, where a bare space is not a valid URI. Any pick of a file with a space or a non-ASCII character in its name was affected.

Builds clean, no new warnings.
